### PR TITLE
DRUPS-30: Improving LogPlugin watchdog logs

### DIFF
--- a/Apigee/Util/OrgConfig.php
+++ b/Apigee/Util/OrgConfig.php
@@ -22,6 +22,7 @@ class OrgConfig
      * @see \Guzzle\Log\MessageFormatter
      */
     const LOG_SUBSCRIBER_FORMAT = <<<EOF
+{method} {resource}
 >>>>>>>>
 {request}
 <<<<<<<<


### PR DESCRIPTION
Fixed LogPlugin watchdogs logs so that the method and resource is shown in the title.